### PR TITLE
Include functions for network request tracing

### DIFF
--- a/android/src/firebase/performance/TitaniumFirebasePerformanceModule.java
+++ b/android/src/firebase/performance/TitaniumFirebasePerformanceModule.java
@@ -78,8 +78,8 @@ public class TitaniumFirebasePerformanceModule extends KrollModule
   @Kroll.method
   public void stopMetric(String url, String httpMethod) {
     if (this.metrics.get(url + httpMethod) == null) { 	
-    Log.e(LCAT, String.format("Cannot find metric for url %s", url + httpMethod));
-    return;
+      Log.e(LCAT, String.format("Cannot find metric for url %s", url + httpMethod));
+      return;
     }
 
     HttpMetric metric = this.metrics.get(url + httpMethod);
@@ -89,8 +89,8 @@ public class TitaniumFirebasePerformanceModule extends KrollModule
   @Kroll.method
   public void setMetricRequestPayloadSize(String url, String httpMethod, long bytes) {
     if (this.metrics.get(url + httpMethod) == null) {	
-    Log.e(LCAT, String.format("Cannot find metric for url %s", url + httpMethod));
-    return;
+      Log.e(LCAT, String.format("Cannot find metric for url %s", url + httpMethod));
+      return;
     }
 
     HttpMetric metric = this.metrics.get(url + httpMethod);
@@ -100,8 +100,8 @@ public class TitaniumFirebasePerformanceModule extends KrollModule
   @Kroll.method
   public void setMetricHttpResponseCode(String url, String httpMethod, int responseCode) {
     if (this.metrics.get(url + httpMethod) == null) {	
-    Log.e(LCAT, String.format("Cannot find metric for url %s", url + httpMethod));
-    return;
+      Log.e(LCAT, String.format("Cannot find metric for url %s", url + httpMethod));
+      return;
     }
 
     HttpMetric metric = this.metrics.get(url + httpMethod);
@@ -111,8 +111,8 @@ public class TitaniumFirebasePerformanceModule extends KrollModule
   @Kroll.method
   public void setMetricResponseContentType(String url, String httpMethod, String contentType) {
     if (this.metrics.get(url + httpMethod) == null) {	
-    Log.e(LCAT, String.format("Cannot find metric for url %s", url + httpMethod));
-    return;
+      Log.e(LCAT, String.format("Cannot find metric for url %s", url + httpMethod));
+      return;
     }
 
     HttpMetric metric = this.metrics.get(url + httpMethod);
@@ -122,8 +122,8 @@ public class TitaniumFirebasePerformanceModule extends KrollModule
   @Kroll.method
   public void setMetricResponsePayloadSize(String url, String httpMethod, long bytes) {
     if (this.metrics.get(url + httpMethod) == null) {	
-    Log.e(LCAT, String.format("Cannot find metric for url %s", url + httpMethod));
-    return;
+      Log.e(LCAT, String.format("Cannot find metric for url %s", url + httpMethod));
+      return;
     }
 
     HttpMetric metric = this.metrics.get(url + httpMethod);
@@ -133,8 +133,8 @@ public class TitaniumFirebasePerformanceModule extends KrollModule
   @Kroll.method
   public void setMetricAttribute(String url, String httpMethod, String attribute, String value) {
     if (this.metrics.get(url + httpMethod) == null) {	
-    Log.e(LCAT, String.format("Cannot find metric for url %s", url + httpMethod));
-    return;
+      Log.e(LCAT, String.format("Cannot find metric for url %s", url + httpMethod));
+      return;
     }
 
     HttpMetric metric = this.metrics.get(url + httpMethod);


### PR DESCRIPTION
Firebase Performance does not support automatic collection of Titanium’s network requests.

These functions provide a way for Firebase Performance to get all the info it needs about each network request made, as per

https://firebase.google.com/docs/perf-mon/custom-network-traces?platform=android

The network request (metric) must be identified within the metric HashMap not only with the url string, but also the httpMethod string, in case two network requests are made in row and both of them have the same url (they could have different httpMethods such as HEAD and then POST)

the difference in code is:
HttpMetric metric = this.metrics.get(url + httpMethod);
instead of
HttpMetric metric = this.metrics.get(url);

Example of starting a network request:
```
Alloy.Globals.FirebasePerformance.startMetric(url, options.requestType);
Alloy.Globals.FirebasePerformance.setMetricAttribute(url, options.requestType, 'requestType', options.requestType);
Alloy.Globals.FirebasePerformance.setMetricAttribute(url, options.requestType, 'url', url);
Alloy.Globals.FirebasePerformance.setMetricRequestPayloadSize(url, options.requestType, 123);
```

Example of ending a network request:
```
Alloy.Globals.FirebasePerformance.setMetricHttpResponseCode(url, <Ti.Network.HTTPClient>.connectionType, <Ti.Network.HTTPClient>.status);
Alloy.Globals.FirebasePerformance.setMetricResponseContentType(url, <Ti.Network.HTTPClient>.connectionType, <Ti.Network.HTTPClient>.responseData.mimeType);
Alloy.Globals.FirebasePerformance.setMetricResponsePayloadSize(url, <Ti.Network.HTTPClient>.connectionType, <Ti.Network.HTTPClient>.responseData.size);
Alloy.Globals.FirebasePerformance.setMetricAttribute(url,  <Ti.Network.HTTPClient>.connectionType, 'responseCode', <Ti.Network.HTTPClient>.status.toString());
Alloy.Globals.FirebasePerformance.stopMetric(url, <Ti.Network.HTTPClient>.connectionType);
```