### PR TITLE
update android firebase-perf to 20.1.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-	implementation 'com.google.firebase:firebase-perf:20.0.3'
+	implementation 'com.google.firebase:firebase-perf:20.1.0'
 }

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.1.0
+version: 2.1.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-firebase-performance


### PR DESCRIPTION
Changes on firebase-perf since 20.0.3: 

**20.0.4:** 
- Improved Performance Monitoring start up time by 25%. This improvement was achieved by moving some component initialization to background threads.

**20.0.5:** 
- Enabled global custom attributes for network request traces.
- Updated log statement to differentiate an event being dropped due to rate limiting and sampling.

**20.0.6:** 
- Fixed a null pointer exception (NPE) when instrumenting network requests. ([GitHub Issue #3406](https://github.com/firebase/firebase-android-sdk/issues/3406))

- Fixed a bug where incorrect session IDs were associated with some foreground and background traces.

- Updated dependencies of play-services-basement, play-services-base, and play-services-tasks to their latest versions (v18.0.0, v18.0.1, and v18.0.1, respectively). For more information, see the [note](https://firebase.google.com/support/release-notes/android#basement18-0-0_base18-0-1_tasks18-0-1) at the top of this release entry.

**20.1.0:** 
- Added support for out-of-the-box measurement of screen performance metrics for [Fragments](https://developer.android.com/guide/fragments). For more details, visit [Learn about screen rendering performance data](https://firebase.google.com/docs/perf-mon/screen-traces?platform=android).

- Fixed a bug where screen traces were not capturing frame metrics for multi-Activity apps.

- Excluded custom attributes that have key/value lengths of 0.