### PR TITLE
fix(android): create variable again

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.1.2
+version: 2.1.3
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-firebase-performance

--- a/android/src/firebase/performance/TitaniumFirebasePerformanceModule.java
+++ b/android/src/firebase/performance/TitaniumFirebasePerformanceModule.java
@@ -71,7 +71,9 @@ public class TitaniumFirebasePerformanceModule extends KrollModule
   public void startMetric(String url, String httpMethod) {
     HttpMetric metric = FirebasePerformance.getInstance().newHttpMetric(url, httpMethod);
     metric.start();
-
+    if (this.metrics == null) {
+      metrics = new HashMap<String, HttpMetric>();
+    }
     this.metrics.put(url + httpMethod, metric);
   }
 	


### PR DESCRIPTION
Was testing an app with `don't keep activities` and I had an error in this module at 

https://github.com/hansemannn/titanium-firebase-performance/blob/master/android/src/firebase/performance/TitaniumFirebasePerformanceModule.java#L75

```
Uncaught Error: Attempt to invoke interface method 'java.lang.Object java.util.Map.put(java.lang.Object, java.lang.Object)' on a null object reference
```

The fix was to check if it is null (because it was destroyed in a previous window) and reinitialize the variable again.

Test version:
[firebase.performance-android-2.1.3.zip](https://github.com/hansemannn/titanium-firebase-performance/files/9873454/firebase.performance-android-2.1.3.zip)
