### PR TITLE
Android - add null checks to avoid errors

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.1.2
+version: 2.1.3
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-firebase-performance

--- a/android/src/firebase/performance/TitaniumFirebasePerformanceModule.java
+++ b/android/src/firebase/performance/TitaniumFirebasePerformanceModule.java
@@ -43,17 +43,26 @@ public class TitaniumFirebasePerformanceModule extends KrollModule
   {
     this.traces.clear();
     this.traces = null;
-    
+
     this.metrics.clear();
     this.metrics = null;
   }
 
   @Kroll.method
   public void startTrace(String identifier) {
-    Trace trace = FirebasePerformance.getInstance().newTrace(identifier);
-    trace.start();
+		if (identifier == null || identifier == "") {
+			Log.e(LCAT, String.format("Invalid identifier for the trace"));
+      return;
+		}
 
-    this.traces.put(identifier, trace);
+		if (this.traces == null) {
+			this.traces = new HashMap<String, Trace>();
+		}
+
+		Trace trace = FirebasePerformance.getInstance().newTrace(identifier);
+		trace.start();
+
+		this.traces.put(identifier, trace);
   }
 
   @Kroll.method
@@ -66,15 +75,24 @@ public class TitaniumFirebasePerformanceModule extends KrollModule
     Trace trace = this.traces.get(identifier);
     trace.stop();
   }
-  
+
   @Kroll.method
   public void startMetric(String url, String httpMethod) {
-    HttpMetric metric = FirebasePerformance.getInstance().newHttpMetric(url, httpMethod);
-    metric.start();
+		if (url == null || httpMethod == null) {
+			Log.e(LCAT, String.format("Invalid parameters for the metric"));
+      return;
+		}
 
-    this.metrics.put(url + httpMethod, metric);
+		if (this.metrics == null) {
+			this.metrics = new HashMap<String, HttpMetric>();
+		}
+
+		HttpMetric metric = FirebasePerformance.getInstance().newHttpMetric(url, httpMethod);
+		metric.start();
+
+		this.metrics.put(url + httpMethod, metric);
   }
-	
+
   @Kroll.method
   public void stopMetric(String url, String httpMethod) {
     if (this.metrics == null || this.metrics.get(url + httpMethod) == null) {
@@ -85,7 +103,7 @@ public class TitaniumFirebasePerformanceModule extends KrollModule
     HttpMetric metric = this.metrics.get(url + httpMethod);
     metric.stop();
   }
-	
+
   @Kroll.method
   public void setMetricRequestPayloadSize(String url, String httpMethod, long bytes) {
     if (this.metrics == null || this.metrics.get(url + httpMethod) == null) {
@@ -107,7 +125,7 @@ public class TitaniumFirebasePerformanceModule extends KrollModule
     HttpMetric metric = this.metrics.get(url + httpMethod);
     metric.setHttpResponseCode(responseCode);
   }
-	
+
   @Kroll.method
   public void setMetricResponseContentType(String url, String httpMethod, String contentType) {
     if (this.metrics == null || this.metrics.get(url + httpMethod) == null) {
@@ -118,7 +136,7 @@ public class TitaniumFirebasePerformanceModule extends KrollModule
     HttpMetric metric = this.metrics.get(url + httpMethod);
     metric.setResponseContentType(contentType);
   }
-	
+
   @Kroll.method
   public void setMetricResponsePayloadSize(String url, String httpMethod, long bytes) {
     if (this.metrics == null || this.metrics.get(url + httpMethod) == null) {
@@ -129,7 +147,7 @@ public class TitaniumFirebasePerformanceModule extends KrollModule
     HttpMetric metric = this.metrics.get(url + httpMethod);
     metric.setResponsePayloadSize(bytes);
   }
-	
+
   @Kroll.method
   public void setMetricAttribute(String url, String httpMethod, String attribute, String value) {
     if (this.metrics == null || this.metrics.get(url + httpMethod) == null) {
@@ -149,7 +167,7 @@ public class TitaniumFirebasePerformanceModule extends KrollModule
     }
 
     Trace trace = this.traces.get(identifier);
-    
+
     trace.incrementMetric(counterName, (long) TiConvert.toInt(incrementedBy));
   }
 }

--- a/ios/Classes/FirebasePerformanceModule.m
+++ b/ios/Classes/FirebasePerformanceModule.m
@@ -77,7 +77,7 @@
   ENSURE_SINGLE_ARG(name, NSString);
 
   if ([[self traces] objectForKey:name] == nil) {
-    [self throwException:[[NSString alloc] initWithFormat:@"Trying to increment the trace \"%@\" which does not exist.", name]
+    [self throwException:[[NSString alloc] initWithFormat:@"Trying to stop the trace \"%@\" which does not exist.", name]
                subreason:@"Start a new trace with \"startTrace('trace_name')\" before"
                 location:CODELOCATION];
     return;

--- a/ios/manifest
+++ b/ios/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.1.0
+version: 2.1.1
 apiversion: 2
 architectures: armv7 arm64 i386 x86_64
 description: titanium-firebase-performance


### PR DESCRIPTION
Hi, 

I got some crash logs with this module on Firebase Crashlytics with this error: 

> Uncaught Error: Attempt to invoke interface method 'java.lang.Object java.util.Map.put(java.lang.Object, java.lang.Object)' on a null object reference 
> firebase.performance.TitaniumFirebasePerformanceModule.startTrace (TitaniumFirebasePerformanceModule.java:56)

So i change the code to verify if the HashMaps are null before insert.

I can't reproduce the crash on my tests, but this conditional will not cause any problem.

[firebase.performance-android-2.1.3.zip](https://github.com/hansemannn/titanium-firebase-performance/files/10467915/firebase.performance-android-2.1.3.zip)
