### PR TITLE
chore(android): update firebase-perf to 20.3.1 and bump version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-	implementation 'com.google.firebase:firebase-perf:20.1.1'
+	implementation 'com.google.firebase:firebase-perf:20.3.1'
 }

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.1.3
+version: 2.1.4
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-firebase-performance


### PR DESCRIPTION
Changes since 20.1.1: 

- Fixed a NullPointerException crash when instrumenting screen traces on Android 7, 8, and 9. ([GitHub Issue #4146](https://github.com/firebase/firebase-android-sdk/issues/4146))